### PR TITLE
fix: Add a tokenSwapUrl to session conf.

### DIFF
--- a/ios/Classes/SpotifySdkConstants.swift
+++ b/ios/Classes/SpotifySdkConstants.swift
@@ -32,6 +32,7 @@ public class SpotifySdkConstants
     public static let methodGetImage = "getImage"
 
     public static let paramClientId = "clientId"
+    public static let paramTokenSwapURL = "tokenSwapUrl"
     public static let paramRedirectUrl = "redirectUrl"
     public static let paramSpotifyUri = "spotifyUri"
     public static let paramAsRadio = "asRadio"
@@ -45,4 +46,5 @@ public class SpotifySdkConstants
     public static let paramTrackIndex = "trackIndex"
     public static let scope = "scope"
     public static let getLibraryState = "getLibraryState"
+     
 }

--- a/ios/Classes/SwiftSpotifySdkPlugin.swift
+++ b/ios/Classes/SwiftSpotifySdkPlugin.swift
@@ -75,6 +75,7 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin, SPTSessionManagerDe
         case SpotifySdkConstants.methodGetAuthorizationCode:
             guard let swiftArguments = call.arguments as? [String:Any],
                 let clientID = swiftArguments[SpotifySdkConstants.paramClientId] as? String,
+                let tokenSwapUrl = swiftArguments[SpotifySdkConstants.paramTokenSwapURL] as? String,
                 let url = swiftArguments[SpotifySdkConstants.paramRedirectUrl] as? String else {
                     result(FlutterError(code: "Arguments Error", message: "One or more arguments are missing", details: nil))
                     return
@@ -93,6 +94,10 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin, SPTSessionManagerDe
                 requestedAuthCode = true
             
                 let configuration = SPTConfiguration(clientID: clientID, redirectURL: redirectURL)
+                // This prevents SDK from auto verifying the authorization code
+                // and generating an access token. Instead, it redirects the
+                // authorization code to the swap url.
+                configuration.tokenSwapURL = URL(string: tokenSwapUrl)
                 mmSessionManager = SPTSessionManager(configuration: configuration, delegate: self)
                 var scopes: [String]?
                 if let additionalScopes = additionalScopes {
@@ -180,7 +185,6 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin, SPTSessionManagerDe
             })
         case SpotifySdkConstants.methodDisconnectFromSpotify:
             appRemote?.disconnect()
-//            appRemote?.connectionParameters.accessToken = nil
             result(true)
         case SpotifySdkConstants.methodPlay:
             guard let appRemote = appRemote else {
@@ -392,12 +396,7 @@ public class SwiftSpotifySdkPlugin: NSObject, FlutterPlugin, SPTSessionManagerDe
     }
     
     public func sessionManager(manager: SPTSessionManager, shouldRequestAccessTokenWith code: String) -> Bool {
-        guard let pkceProvider = manager.value(forKey: "PKCEProvider"),
-              let codeVerifier:String = (pkceProvider as AnyObject).value(forKey: "codeVerifier") as? String else {
-            connectionStatusHandler?.codeResult?(FlutterError(code: "errorConnecting", message: "codeVerifier is null", details: ["code": code]))
-            return false
-       }
-        connectionStatusHandler?.codeResult?(["code": code, "code_verifier": codeVerifier])
+        connectionStatusHandler?.codeResult?(code)
         return true
     }
 

--- a/lib/platform_channels.dart
+++ b/lib/platform_channels.dart
@@ -117,6 +117,9 @@ class ParamNames {
   /// param name for [redirectUrl]
   static const String redirectUrl = 'redirectUrl';
 
+  /// param name for [tokenSwapUrl]
+  static const String tokenSwapUrl = 'tokenSwapUrl';
+
   /// param name for [scope]
   static const String scope = 'scope';
 

--- a/lib/spotify_sdk.dart
+++ b/lib/spotify_sdk.dart
@@ -107,21 +107,24 @@ class SpotifySdk {
   /// failed.
   /// Throws a [MissingPluginException] if the method is not implemented on
   /// the native platforms.
-  static Future<String> getAccessToken(
-      {required String clientId,
-      required String redirectUrl,
-      String spotifyUri = '',
-      bool asRadio = false,
-      String? scope}) async {
+  static Future<String> getAccessToken({
+    required String clientId,
+    required String redirectUrl,
+    String spotifyUri = '',
+    bool asRadio = false,
+    String? scope,
+  }) async {
     try {
-      final authorization =
-          await _channel.invokeMethod(MethodNames.getAccessToken, {
-        ParamNames.clientId: clientId,
-        ParamNames.redirectUrl: redirectUrl,
-        ParamNames.scope: scope,
-        ParamNames.spotifyUri: spotifyUri,
-        ParamNames.asRadio: asRadio,
-      });
+      final authorization = await _channel.invokeMethod(
+        MethodNames.getAccessToken,
+        {
+          ParamNames.clientId: clientId,
+          ParamNames.redirectUrl: redirectUrl,
+          ParamNames.scope: scope,
+          ParamNames.spotifyUri: spotifyUri,
+          ParamNames.asRadio: asRadio,
+        },
+      );
       return authorization.toString();
     } on Exception catch (e) {
       _logException(MethodNames.getAccessToken, e);
@@ -144,42 +147,28 @@ class SpotifySdk {
   /// failed.
   /// Throws a [MissingPluginException] if the method is not implemented on
   /// the native platforms.
-  static Future<Map<String, String?>> getAuthorizationCode(
-      {required String clientId,
-      required String redirectUrl,
-      String? scope}) async {
+  static Future<String> getAuthorizationCode({
+    required String clientId,
+    required String redirectUrl,
+    required String tokenSwapUrl,
+    String? scope,
+  }) async {
     try {
-      final authorization =
-          await _channel.invokeMethod(MethodNames.getAuthorizationCode, {
-        ParamNames.clientId: clientId,
-        ParamNames.redirectUrl: redirectUrl,
-        ParamNames.scope: scope,
-      });
-
-      return {
-        'code': authorization['code'] as String?,
-        'code_verifier': authorization['code_verifier'] as String?,
-      };
+      final authorization = await _channel.invokeMethod(
+        MethodNames.getAuthorizationCode,
+        {
+          ParamNames.clientId: clientId,
+          ParamNames.redirectUrl: redirectUrl,
+          ParamNames.tokenSwapUrl: tokenSwapUrl,
+          ParamNames.scope: scope,
+        },
+      );
+      return authorization.toString();
     } on Exception catch (e) {
       _logException(MethodNames.getAuthorizationCode, e);
       rethrow;
     }
   }
-
-  @Deprecated('Use [getAccessToken]')
-  static Future<String> getAuthenticationToken(
-          {required String clientId,
-          required String redirectUrl,
-          String spotifyUri = '',
-          bool asRadio = false,
-          String? scope}) =>
-      getAccessToken(
-        clientId: clientId,
-        redirectUrl: redirectUrl,
-        spotifyUri: spotifyUri,
-        asRadio: asRadio,
-        scope: scope,
-      );
 
   /// Logs the user out and disconnects the app from the users spotify account
   ///


### PR DESCRIPTION
This prevents SDK to automatically verify the authorization code and generate an access token.
We also retrieve the token swap url from the flutter client.